### PR TITLE
Implement Fingerprint Extraction from BIP380 descriptors

### DIFF
--- a/.changeset/sharp-cows-promise.md
+++ b/.changeset/sharp-cows-promise.md
@@ -1,0 +1,6 @@
+---
+"@caravan/descriptors": patch
+---
+
+Add getFingerprintFromBip380Descriptor utility to extract fingerprints from BIP380 descriptors.
+

--- a/src/descriptors.test.ts
+++ b/src/descriptors.test.ts
@@ -6,6 +6,7 @@ import {
   encodeDescriptorWithMultipath,
   getChecksum,
   getWalletFromDescriptor,
+  getFingerprintFromBip380Descriptor,
 } from "./descriptors";
 import {
   EXTERNAL_BRAID,
@@ -322,5 +323,43 @@ describe("Multipath Notation Support (<0;1>)", () => {
       expect(config.addressType).toEqual("P2WSH");
       expect(config.keyOrigins.length).toEqual(MULTIPATH.keys.length);
     });
+  });
+});
+
+describe("getFingerprintFromBip380Descriptor", () => {
+  it("should extract fingerprint from BIP380 descriptor with key origin", () => {
+    // Test vector from BIP380: wpkh with key origin
+    const descriptor =
+      "wpkh([d34db33f/44'/0'/0']xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/1/*)";
+    const result = getFingerprintFromBip380Descriptor(descriptor);
+    expect(result).toBe("d34db33f");
+  });
+
+  it("should extract fingerprint from BIP380 descriptor with sh(wpkh) and key origin", () => {
+    // Test vector from BIP380: sh(wpkh) with key origin
+    const descriptor =
+      "sh(wpkh([d34db33f/44'/0'/0']xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/1/*))";
+    const result = getFingerprintFromBip380Descriptor(descriptor);
+    expect(result).toBe("d34db33f");
+  });
+
+  it("should return null for BIP380 descriptor without key origin", () => {
+    // Test vector from BIP380: wpkh without key origin
+    const descriptor =
+      "wpkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/1/0)";
+    const result = getFingerprintFromBip380Descriptor(descriptor);
+    expect(result).toBeNull();
+  });
+
+  it("should return null for invalid descriptor", () => {
+    const descriptor = "invalid";
+    const result = getFingerprintFromBip380Descriptor(descriptor);
+    expect(result).toBeNull();
+  });
+
+  it("should handle uppercase fingerprint and return lowercase", () => {
+    const descriptor = "wpkh([D34DB33F/44'/0'/0']xpub...)";
+    const result = getFingerprintFromBip380Descriptor(descriptor);
+    expect(result).toBe("d34db33f");
   });
 });

--- a/src/descriptors.ts
+++ b/src/descriptors.ts
@@ -11,6 +11,8 @@ import {
   CHECKSUM_REGEX,
 } from "./multipath";
 
+const FINGERPRINT_REGEX = /\[([a-f0-9]+)\//i;
+
 // should be a 32 byte hex string
 export type PolicyHmac = string;
 // should be an 8 byte hex string
@@ -226,8 +228,23 @@ export const getWalletFromDescriptor = async (
   return await decodeDescriptors(internal, external, network);
 };
 
+/**
+ * Extracts the key fingerprint from a BIP380 descriptor string.
+ * The fingerprint is part of the key origin information, enclosed in square brackets
+ * followed by a derivation path and a slash, as defined in BIP380.
+ *
+ * @param descriptor - The BIP380 descriptor string to parse.
+ * @returns The extracted fingerprint as a lowercase hex string, or null if not found.
+ */
+export const getFingerprintFromBip380Descriptor = (
+  descriptor: string,
+): string | null => {
+  return descriptor.match(FINGERPRINT_REGEX)?.[1]?.toLowerCase() || null;
+};
+
 export default {
   encodeDescriptors,
   encodeDescriptorWithMultipath,
   decodeDescriptors,
+  getFingerprintFromBip380Descriptor,
 };


### PR DESCRIPTION
# Summary
                                                                         
Implement fingerprint extraction from BIP380 descriptors                        
                                                                         
This change adds a new function `getFingerprintFromBip380Descriptor` to extract the master key fingerprint from BIP380 descriptor strings. The function parses the key origin information (enclosed in square brackets) and returns the fingerprint as a lowercase hex string.

# Key Changes

 - New function: `getFingerprintFromBip380Descriptor(descriptor: string):
string | null`
 - Uses regex pattern to match [fingerprint]/ format
 - Returns fingerprint in lowercase hex or null if not found
 - Handles both uppercase and lowercase input

 - Comprehensive tests covering:
 - wpkh descriptors with key origin
 - sh(wpkh) descriptors with key origin
 - Descriptors without key origin (returns null)
 - Invalid descriptors (returns null)
 - Case normalization to lowercase

# Usage
```
const descriptor = "wpkh([d34db33f/44'/0'/0']xpub.../1/*)";
const fingerprint = getFingerprintFromBip380Descriptor(descriptor);
// Returns: "d34db33f"
```

This enhancement improves compatibility with BIP380 standards and provides
convenient access to fingerprint information for wallet management and key
identification.